### PR TITLE
LW-890 Add request timeout and retries.

### DIFF
--- a/serviceRequests/requestType.py
+++ b/serviceRequests/requestType.py
@@ -3,6 +3,9 @@ import urllib2
 import socket
 
 class RequestType(object):
+  MAX_RETRIES = 2
+  URL_TIMEOUT = 8 #  seconds
+
   def __init__(self, netid):
     super(RequestType, self).__init__()
     self.netid = netid
@@ -19,13 +22,13 @@ class RequestType(object):
     req = urllib2.Request(url, None, headers)
     response = ""
     try:
-      response = urllib2.urlopen(req, timeout=8)
+      response = urllib2.urlopen(req, timeout=self.URL_TIMEOUT)
     except urllib2.HTTPError as e:
       heslog.error("%s" % e.code)
       heslog.error(e.read())
       return None
     except urllib2.URLError as e:
-      if isinstance(e.reason, socket.timeout) and retryCount < 2:
+      if isinstance(e.reason, socket.timeout) and retryCount < self.MAX_RETRIES:
         heslog.info('Request timed out. Retrying.')
         return self._makeReq(url, headers, retryCount + 1)
       else:


### PR DESCRIPTION
Set at max 2 retries and 8 seconds per request = 24 seconds, within the 30 second lambda timeout.