### PR TITLE
LW-913 Implement authorization for Okta clients other than netids.

### DIFF
--- a/deploy/config.yml
+++ b/deploy/config.yml
@@ -51,6 +51,9 @@ LambdaEnv:
         -
           Name: ALEPH_URL
           Value: ${ALEPH_URL}
+        -
+          Name: AUTHORIZED_CLIENTS
+          Value: ${AUTHORIZED_CLIENTS}
 
     - FunctionName: $SERVICE-$STAGE-alephQuery
       Environment:
@@ -63,6 +66,9 @@ LambdaEnv:
         -
           Name: ALEPH_ITEM_PATH
           Value: ${ALEPH_ITEM_PATH}
+        -
+          Name: AUTHORIZED_CLIENTS
+          Value: ${AUTHORIZED_CLIENTS}
 
     - FunctionName: $SERVICE-$STAGE-alephCircHistory
       Environment:
@@ -78,6 +84,9 @@ LambdaEnv:
         -
           Name: ALEPH_ORACLE_SID
           Value: ${ALEPH_ORACLE_SID}
+        -
+          Name: AUTHORIZED_CLIENTS
+          Value: ${AUTHORIZED_CLIENTS}
 
     - FunctionName: $SERVICE-$STAGE-alephUserInfo
       Environment:
@@ -93,6 +102,9 @@ LambdaEnv:
         -
           Name: ALEPH_ORACLE_SID
           Value: ${ALEPH_ORACLE_SID}
+        -
+          Name: AUTHORIZED_CLIENTS
+          Value: ${AUTHORIZED_CLIENTS}
 
     - FunctionName: $SERVICE-$STAGE-alephRenew
       Environment:
@@ -108,6 +120,9 @@ LambdaEnv:
         -
           Name: ALEPH_RENEW_PATH
           Value: ${ALEPH_RENEW_PATH}
+        -
+          Name: AUTHORIZED_CLIENTS
+          Value: ${AUTHORIZED_CLIENTS}
 
     - FunctionName: $SERVICE-$STAGE-alephUpdate
       Environment:
@@ -129,6 +144,9 @@ LambdaEnv:
         -
           Name: ALEPH_PASS
           Value: ${ALEPH_PASS}
+        -
+          Name: AUTHORIZED_CLIENTS
+          Value: ${AUTHORIZED_CLIENTS}
 
     - FunctionName: $SERVICE-$STAGE-illiad
       Environment:
@@ -138,6 +156,9 @@ LambdaEnv:
         -
           Name: ILLIAD_URL
           Value: ${ILLIAD_URL}
+        -
+          Name: AUTHORIZED_CLIENTS
+          Value: ${AUTHORIZED_CLIENTS}
 
     - FunctionName: $SERVICE-$STAGE-primo
       Environment:

--- a/deploy/gateway.yml
+++ b/deploy/gateway.yml
@@ -307,11 +307,16 @@ Resources:
           /aleph/circhistory:
             get:
               parameters:
-              - name: "aleph-id"
+              - name: "Authorization"
                 in: "header"
                 required: true
                 type: "string"
-                description: "The aleph id of the user to query for"
+                description: "The JWT authorization token."
+              - name: "netid"
+                in: "query"
+                required: true
+                type: "string"
+                description: "The net id of the user to query for"
               responses:
                 "200":
                   description: User Circulation History

--- a/serviceHandler.py
+++ b/serviceHandler.py
@@ -17,8 +17,17 @@ def aleph(event, context):
   heslog.addLambdaContext(event, context, fn="aleph", requestType=requestType)
 
   if netid is None:
-    heslog.error("no netid")
-    return response.error(401)
+    clientId = event.get("requestContext", {}).get("authorizer", {}).get("clientid", None)
+    authorizedClients = hesutil.getEnv("AUTHORIZED_CLIENTS", throw=True).split(',')
+
+    if clientId is None:
+      heslog.error("Invalid token or no token provided")
+      return response.error(400)
+    elif clientId not in authorizedClients:
+      heslog.error("Okta client " + clientId + " is not authorized to perform this action.")
+      return response.error(401)
+    else:
+      netid = queryParams.get("netid")
 
   if requestType is None:
     heslog.error("no query type specified")
@@ -39,13 +48,23 @@ def aleph(event, context):
 def illiad(event, context):
   path = event.get("path")
   requestType = path.split('/')[-1]
+  queryParams = event.get("queryStringParameters") or {}
   netid = event.get("requestContext", {}).get("authorizer", {}).get("netid", None)
 
   heslog.addLambdaContext(event, context, fn="illiad", requestType=requestType)
 
   if netid is None:
-    heslog.error("no netid")
-    return response.error(401)
+    clientId = event.get("requestContext", {}).get("authorizer", {}).get("clientid", None)
+    authorizedClients = hesutil.getEnv("AUTHORIZED_CLIENTS", throw=True).split(',')
+
+    if clientId is None:
+      heslog.error("Invalid token or no token provided")
+      return response.error(400)
+    elif clientId not in authorizedClients:
+      heslog.error("Okta client " + clientId + " is not authorized to perform this action.")
+      return response.error(401)
+    else:
+      netid = queryParams.get("netid")
 
   if requestType is None:
     heslog.error("no query type specified")

--- a/serviceRequests/alephDirectSql.py
+++ b/serviceRequests/alephDirectSql.py
@@ -34,7 +34,24 @@ class AlephOracle(object):
     self.cursor = self.connection.cursor()
 
 
-  def userCircHistory(self, alephID):
+  def userCircHistory(self, netID):
+    # First get their aleph id. It's quicker and easier to do this in its own query
+    alephID = None
+    query = """
+      SELECT TRIM(z308_id) netid
+      FROM pwd50.z308
+      WHERE z308_verification_type = '02'
+        AND SUBSTR(z308_rec_key, 1, 2) = '04'
+        AND TRIM(SUBSTR(z308_rec_key, 3)) = UPPER(:netID)
+    """
+    self.cursor.execute(query, netID = netID)
+    for values in self.cursor:
+      alephID = values[0]
+
+    # if we didn't find an aleph account for the netid, don't bother continuing.
+    if alephID is None:
+      return None
+
     sql = """
       SELECT
         z36.*,


### PR DESCRIPTION
Accept netid as a query param so that an authorized service can choose which user to fetch data for, rather than needing to authenticate _as_ that user.

To prevent unauthorized access, this parameter only functions if the token doesn't have a netid (e.g. it is a service, not a user) AND the client id from the token exists in the environment variable `AUTHRIZED_CLIENTS` (comma-delimited)